### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,15 +6,15 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SevenSegmentDisplay4Digit    KEYWORD1
+SevenSegmentDisplay4Digit	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-refresh    KEYWORD2
-setNumber    KEYWORD2
-setPointAt    KEYWORD2
+refresh	KEYWORD2
+setNumber	KEYWORD2
+setPointAt	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords